### PR TITLE
Limit size of filename on command line arguments.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ input.o: input.c estruct.h edef.h
 isearch.o: isearch.c estruct.h edef.h
 line.o: line.c estruct.h edef.h
 lock.o: lock.c estruct.h edef.h
-main.o: main.c estruct.h efunc.h edef.h ebind.h
+main.o: main.c estruct.h efunc.h edef.h ebind.h util.h
 pklock.o: pklock.c estruct.h
 posix.o: posix.c estruct.h utf8.h
 random.o: random.c estruct.h edef.h

--- a/main.c
+++ b/main.c
@@ -61,6 +61,7 @@
 #include "efunc.h"   /* Function declarations and name table. */
 #include "ebind.h"   /* Default key bindings. */
 #include "version.h"
+#include "util.h"
 
 /* For MSDOS, increase the default stack space. */
 #if MSDOS & TURBO
@@ -237,7 +238,7 @@ int main(int argc, char **argv)
 
 			/* set this to inactive */
 			bp = bfind(bname, TRUE, 0);
-			strcpy(bp->b_fname, argv[carg]);
+ 			mystrscpy(bp->b_fname, argv[carg], sizeof bp->b_fname);
 			bp->b_active = FALSE;
 			if (firstfile) {
 				firstbp = bp;


### PR DESCRIPTION
Avoid crash when filename on command line is longer than NFILEN.
Just truncates the filename without feedback to user.