### PR TITLE
Fix paragraph moving logic to avoid stuck at line beginning with number

### DIFF
--- a/basic.c
+++ b/basic.c
@@ -285,7 +285,7 @@ static int is_new_para(void)
 #endif
 			return 1;
 		}
-		if (!isletter(c))
+		if (!isletter(c) && !isnumber(c))
 			return 1;
 		return 0;
 	}

--- a/estruct.h
+++ b/estruct.h
@@ -357,16 +357,19 @@
 #define isletter(c)	(('a' <= c && LASTLL >= c) || ('A' <= c && LASTUL >= c) || (128<=c && c<=167))
 #define islower(c)	(('a' <= c && LASTLL >= c))
 #define isupper(c)	(('A' <= c && LASTUL >= c))
+#define isnumber(c)	(('0' <= c && '9' >= c))
 
 #else
 
 #define isletter(c)	isxletter((0xFF & (c)))
 #define islower(c)	isxlower((0xFF & (c)))
 #define isupper(c)	isxupper((0xFF & (c)))
+#define isnumber(c)	isxnumber((0xFF & (c)))
 
 #define isxletter(c)	(('a' <= c && LASTLL >= c) || ('A' <= c && LASTUL >= c) || (192<=c && c<=255))
 #define isxlower(c)	(('a' <= c && LASTLL >= c) || (224 <= c && 252 >= c))
 #define isxupper(c)	(('A' <= c && LASTUL >= c) || (192 <= c && 220 >= c))
+#define isxnumber(c)	(('0' <= c && '9' >= c))
 
 #endif
 

--- a/word.c
+++ b/word.c
@@ -385,7 +385,7 @@ int inword(void)
 	if (c >= 'A' && c <= 'Z')
 #endif
 		return TRUE;
-	if (c >= '0' && c <= '9')
+	if (isnumber(c))
 		return TRUE;
 	return FALSE;
 }


### PR DESCRIPTION
The check in is_new_para() should match that of inword(). The current
codes only check isletter in is_new_para() while inword() also checks
number. This causes Meta-P (gotobop) to stuck at line beginning with number.

To reproduce the problem, use em to open the README file and do Meta-P
from the end of the file. And it will stuck at the line '1991.'.

Fix to also check numberic chars in is_new_para() function.

Signed-off-by: Chen Qi <chen_q07@163.com>