### PR TITLE
Fix 'updpos()' and 'updateline()' functions for UTF-8 characters

### DIFF
--- a/UTF-8-demo.txt
+++ b/UTF-8-demo.txt
@@ -198,7 +198,7 @@ Compact font selection example text:
 
 Greetings in various languages:
 
-  Hello world, Καλημέρα κόσμε, コンニチハ
+  Hello world, Καλημέρα κόσμε, コンニチハ, 你好
 
 Box drawing alignment tests:                                          █
                                                                       ▉

--- a/display.c
+++ b/display.c
@@ -549,7 +549,7 @@ void updpos(void)
 		if (c == '\t')
 			curcol |= tabmask;
 
-		++curcol;
+		curcol += char_width(c);
 	}
 
 	/* if extended, flag so and update the virtual line image */
@@ -949,6 +949,7 @@ static int updateline(int row, struct video *vp1, struct video *vp2)
 	int nbflag;	/* non-blanks to the right flag? */
 	int rev;		/* reverse video flag */
 	int req;		/* reverse video request flag */
+	int ncol = 0;
 
 
 	/* set up pointers to virtual and physical lines */
@@ -981,7 +982,7 @@ static int updateline(int row, struct video *vp1, struct video *vp2)
 		cp3 = &vp1->v_text[term.t_ncol];
 		while (cp1 < cp3) {
 			TTputc(*cp1);
-			++ttcol;
+			ttcol += char_width(*cp1);
 			*cp2++ = *cp1++;
 		}
 		/* turn rev video off */
@@ -1004,6 +1005,7 @@ static int updateline(int row, struct video *vp1, struct video *vp2)
 
 	/* advance past any common chars at the left */
 	while (cp1 != &vp1->v_text[term.t_ncol] && cp1[0] == cp2[0]) {
+		ncol += char_width(cp1[0]);
 		++cp1;
 		++cp2;
 	}
@@ -1043,14 +1045,14 @@ static int updateline(int row, struct video *vp1, struct video *vp2)
 			cp5 = cp3;	/* fewer characters. */
 	}
 
-	movecursor(row, cp1 - &vp1->v_text[0]);	/* Go to start of line. */
+	movecursor(row, ncol);	/* Go to start of line. */
 #if	REVSTA
 	TTrev(rev);
 #endif
 
 	while (cp1 != cp5) {	/* Ordinary. */
 		TTputc(*cp1);
-		++ttcol;
+		ttcol += char_width(*cp1);
 		*cp2++ = *cp1++;
 	}
 

--- a/utf8.c
+++ b/utf8.c
@@ -96,3 +96,35 @@ unsigned unicode_to_utf8(unsigned int c, char *utf8)
 	}
 	return bytes;
 }
+
+#define WIDTH_ROW 38
+
+static unsigned int widths[WIDTH_ROW][2] = {
+	{126,    1}, {159,    0}, {687,     1}, {710,   0}, {711,   1},
+	{727,    0}, {733,    1}, {879,     0}, {1154,  1}, {1161,  0},
+	{4347,   1}, {4447,   2}, {7467,    1}, {7521,  0}, {8369,  1},
+	{8426,   0}, {9000,   1}, {9002,    2}, {11021, 1}, {12350, 2},
+	{12351,  1}, {12438,  2}, {12442,   0}, {19893, 2}, {19967, 1},
+	{55203,  2}, {63743,  1}, {64106,   2}, {65039, 1}, {65059, 0},
+	{65131,  2}, {65279,  1}, {65376,   2}, {65500, 1}, {65510, 2},
+	{120831, 1}, {262141, 2}, {1114109, 1}
+};
+
+/*
+ * char_width()
+ *
+ * Get the character display width.
+ */
+int char_width(unsigned int c)
+{
+	int i;
+
+	if (c == 0xe || c == 0xf)
+		return 0;
+
+	for (i = 0; i < WIDTH_ROW; i++) {
+		if (c <= widths[i][0])
+			return widths[i][1];
+	}
+	return 1;
+}

--- a/utf8.h
+++ b/utf8.h
@@ -11,4 +11,6 @@ static inline int is_beginning_utf8(unsigned char c)
 	return (c & 0xc0) != 0x80;
 }
 
+int char_width(unsigned int c);
+
 #endif


### PR DESCRIPTION
When deal with multibyte UTF-8 characters, these functions DO NOT
correctly calculate the display width of the characters.