### PR TITLE
Fix filename extension detection on relative paths

### DIFF
--- a/efunc.h
+++ b/efunc.h
@@ -346,6 +346,7 @@ extern char *mklower(char *str);
 extern int abs(int x);
 extern int ernd(void);
 extern int sindex(char *source, char *pattern);
+extern int rsindex(char *source, char *pattern);
 extern char *xlat(char *source, char *lookup, char *trans);
 
 /* crypt.c */

--- a/emacs.rc
+++ b/emacs.rc
@@ -198,7 +198,7 @@ bind-to-key execute-macro-40 M-?
 		add-mode "wrap"
 		!return
 	!endif
-	set %rctmp &sin $cfname "."
+	set %rctmp &sir $cfname "."
 	!if &equ %rctmp 0
 		!return
 	!endif

--- a/eval.c
+++ b/eval.c
@@ -166,6 +166,8 @@ char *gtfun(char *fname)
 		return itoa(~atoi(arg1));
 	case UFXLATE:
 		return xlat(arg1, arg2, arg3);
+	case UFRSINDEX:
+		return itoa(rsindex(arg1, arg2));
 	}
 
 	exit(-11);		/* never should get here */
@@ -966,6 +968,48 @@ int sindex(char *source, char *pattern)
 		if (*cp == 0)
 			return (int) (sp - source) + 1;
 		++sp;
+	}
+
+	/* no match at all.. */
+	return 0;
+}
+
+/*
+ * reverse find pattern within source
+ *
+ * char *source;	source string to search
+ * char *pattern;	string to look for
+ */
+int rsindex(char *source, char *pattern)
+{
+	char *sp;		/* ptr to current position to scan */
+	char *csp;		/* ptr to source string during comparison */
+	char *cp;		/* ptr to place to check for equality */
+	int lp;
+	int ls;
+
+	ls = strlen(source);
+	lp = strlen(pattern);
+	if (ls == 0 || lp == 0 || ls < lp)
+		return 0;
+
+	/* scanning through the source string */
+	sp = source + ls - lp;
+	while (sp >= source) {
+		/* scan through the pattern */
+		cp = pattern;
+		csp = sp;
+		while (*cp) {
+			if (!eq(*cp, *csp))
+				break;
+			++cp;
+			++csp;
+		}
+
+		/* was it a match? */
+		if (*cp == 0)
+			return (int) (sp - source) + 1;
+		--sp;
 	}
 
 	/* no match at all.. */

--- a/evar.h
+++ b/evar.h
@@ -162,6 +162,7 @@ static struct user_function funcs[] = {
 	{ "bxo", DYNAMIC },	/* bitwise xor   9-10-87  jwm */
 	{ "bno", MONAMIC },	/* bitwise not */
 	{ "xla", TRINAMIC },	/* XLATE character string translation */
+	{ "sir", DYNAMIC }	/* reverse find the index of one string in another */
 };
 
 /* And its preprocesor definitions. */
@@ -205,5 +206,6 @@ static struct user_function funcs[] = {
 #define UFBXOR		36
 #define	UFBNOT		37
 #define	UFXLATE		38
+#define UFRSINDEX	39
 
 #endif  /* EVAR_H_ */


### PR DESCRIPTION
Added "sir" (reverse string index search) function to eval.c which
enables the emacs.rc script to fetch the filename extension correctly even
when loading the file using a relative path.

Signed-off-by: Luiz A. Bühnemann <laugusto@senhasegura.com>