### PR TITLE
Replace cuserid

### DIFF
--- a/pklock.c
+++ b/pklock.c
@@ -80,8 +80,7 @@ char *dolock(char *fname)
 	}
 	if ((n = read(fd, locker, MAXNAME)) < 1) {
 		lseek(fd, 0, SEEK_SET);
-/*		strcpy(locker, getlogin()); */
-		cuserid(locker);
+		strcpy(locker, getlogin());
 		strcat(locker + strlen(locker), "@");
 		gethostname(locker + strlen(locker), 64);
 		write(fd, locker, strlen(locker));


### PR DESCRIPTION
cuserid [has been removed from some toolchains](https://autobuild.buildroot.org/results/f409609dcdd4bc835bf5e75c3ac8a1f141679102/build-end.log) and is no longer in the POSIX standard since 1990. getlogin has been in the standard since 2001.

This commit uncomments the call to getlogin and thus replaces cuserid with getlogin.