### PR TITLE
Simplify UEmacs Installation with a precompiled binary and public mirror

### DIFF
--- a/README
+++ b/README
@@ -143,7 +143,7 @@ o  VMS:  To compile use '@VMSMAKE', install manually, uEmacs/PK uses a
          logical name EMACS_DIR to locate its initialization files.
 
 
-OR IF YOU PREFER A PRECOMPILED VERSION 
+OR IF YOU PREFER A PRECOMPILED BINARY
 
 WGET/CURL: wget https://bionicbeaverlinux2.github.io/uemacs-precompiled/uemacs-precompiled.tar.gx 
 or 


### PR DESCRIPTION
I understand the installation process can be confusing, but I believe this will make it much easier.

This commit adds a precompiled uEmacs binary to simplify packaging and improve operating system compatibility.  
Just download it with:

  wget https://bionicbeaverlinux2.github.io/uemacs-precompiled/uemacs-precompiled.tar.gz

or

  curl -LO https://bionicbeaverlinux2.github.io/uemacs-precompiled/uemacs-precompiled.tar.gz

Extract it wherever you like:

  tar -xvf uemacs-precompiled.tar.gz

Then simply run:

  ./ed

It’s a small change, but it saves everyone from having to rebuild the editor from source and improves compatibility across all oses.

Thanks,  
Have a great day!  
— Bionic
