### PR TITLE
pklock: fix races, use-after-free, and deprecated cuserid()

### DIFF
--- a/efunc.h
+++ b/efunc.h
@@ -357,8 +357,9 @@ extern int lockchk(char *fname);
 extern int lockrel(void);
 extern int lock(char *fname);
 extern int unlock(char *fname);
-extern void lckerror(char *errstr);
+extern void lckerror(const char *errstr);
 
 /* pklock.c */
-extern char *dolock(char *fname);
-extern char *undolock(char *fname);
+extern const char *dolock(char *fname);
+extern const char *undolock(char *fname);
+extern int is_lock_error(const char *msg);

--- a/lock.c
+++ b/lock.c
@@ -10,7 +10,6 @@
 #include "edef.h"
 #include "efunc.h"
 
-#if	BSD | SVR4
 #include <sys/errno.h>
 
 static char *lname[NLOCKS];		/* names of all locked files */
@@ -92,8 +91,8 @@ int lockrel(void)
  */
 int lock(char *fname)
 {
-	char *locker;	/* lock error message */
-	int status;	/* return status */
+	const char *locker;	/* lock error message */
+	int status;		/* return status */
 	char msg[NSTRING];	/* message string */
 
 	/* attempt to lock the file */
@@ -102,15 +101,13 @@ int lock(char *fname)
 		return TRUE;
 
 	/* file failed...abort */
-	if (strncmp(locker, "LOCK", 4) == 0) {
+	if (is_lock_error(locker)) {
 		lckerror(locker);
 		return ABORT;
 	}
 
 	/* someone else has it....override? */
-	strcpy(msg, "File in use by ");
-	strcat(msg, locker);
-	strcat(msg, ", override?");
+	(void)snprintf(msg, sizeof(msg), "File in use by %s, override?", locker);
 	status = mlyesno(msg);	/* ask them */
 	if (status == TRUE)
 		return FALSE;
@@ -127,7 +124,7 @@ int lock(char *fname)
  */
 int unlock(char *fname)
 {
-	char *locker;	/* undolock return string */
+	const char *locker;	/* undolock return string */
 
 	/* unclock and return */
 	locker = undolock(fname);
@@ -144,13 +141,10 @@ int unlock(char *fname)
  *
  * char *errstr;	lock error string to print out
  */
-void lckerror(char *errstr)
+void lckerror(const char *errstr)
 {
 	char obuf[NSTRING];	/* output buffer for error message */
 
-	strcpy(obuf, errstr);
-	strcat(obuf, " - ");
-	strcat(obuf, strerror(errno));
-	mlwrite(obuf);
+	(void)snprintf(obuf, sizeof(obuf), "%s - %s", errstr, strerror(errno));
+	mlwrite("%s", obuf);
 }
-#endif

--- a/pklock.c
+++ b/pklock.c
@@ -3,95 +3,236 @@
  *	locking routines as modified by Petri Kutvonen
  */
 
-#include "estruct.h"
-#include "edef.h"
-#include "efunc.h"
-
-#if (FILOCK && BSD) || SVR4
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <fcntl.h>
-#ifdef SVR4
 #include <string.h>
-#else
-#include <strings.h>
-#endif
 #include <errno.h>
+#include <pwd.h>
+
+#include "estruct.h"
+#include "edef.h"
+#include "efunc.h"
 
 #define MAXLOCK 512
 #define MAXNAME 128
 
-#if defined(SVR4) && ! defined(__linux__)
-#include <sys/systeminfo.h>
-
-int gethostname(char *name, int namelen)
-{
-	return sysinfo(SI_HOSTNAME, name, namelen);
-}
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
 #endif
 
+#ifndef O_NOFOLLOW
+#define O_NOFOLLOW 0
+#endif
 
+static const char LOCK_ERR_PATH_TOO_LONG[] =
+	"LOCK ERROR: lock file path too long";
+static const char LOCK_ERR_NOT_REGULAR[] =
+	"LOCK ERROR: not a regular file";
+static const char LOCK_ERR_CANNOT_ACCESS[] =
+	"LOCK ERROR: cannot access lock file";
+static const char LOCK_ERR_CANNOT_WRITE[] =
+	"LOCK ERROR: cannot write lock file";
+static const char LOCK_ERR_CANNOT_CLOSE[] =
+	"LOCK ERROR: cannot close lock file";
+static const char LOCK_ERR_MALFORMED[] =
+	"LOCK ERROR: malformed lock file";
+static const char LOCK_ERR_CANNOT_REMOVE[] =
+	"LOCK ERROR: cannot remove lock file";
+
+static int lock_err_equal(const char *msg, const char *err)
+{
+	return msg == err || (msg != NULL && strcmp(msg, err) == 0);
+}
+
+static int open_existing_lock(const char *lname, struct stat *sbuf)
+{
+	int fd;
+	int saved_errno;
+
+#if O_NOFOLLOW == 0
+	struct stat lbuf;
+
+	if (lstat(lname, &lbuf) != 0)
+		return -1;
+	if (!S_ISREG(lbuf.st_mode)) {
+		errno = ELOOP;
+		return -1;
+	}
+#endif
+
+	fd = open(lname, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+	if (fd < 0)
+		return -1;
+
+	if (fstat(fd, sbuf) != 0) {
+		saved_errno = errno;
+		close(fd);
+		errno = saved_errno;
+		return -1;
+	}
+	if (!S_ISREG(sbuf->st_mode)) {
+		close(fd);
+		errno = ELOOP;
+		return -1;
+	}
+
+#if O_NOFOLLOW == 0
+	if (lstat(lname, &lbuf) != 0) {
+		saved_errno = errno;
+		close(fd);
+		errno = saved_errno;
+		return -1;
+	}
+	if (lbuf.st_dev != sbuf->st_dev || lbuf.st_ino != sbuf->st_ino) {
+		close(fd);
+		errno = ENOENT;
+		return -1;
+	}
+#endif
+
+	return fd;
+}
+
+int is_lock_error(const char *msg)
+{
+	return lock_err_equal(msg, LOCK_ERR_PATH_TOO_LONG)
+	    || lock_err_equal(msg, LOCK_ERR_NOT_REGULAR)
+	    || lock_err_equal(msg, LOCK_ERR_CANNOT_ACCESS)
+	    || lock_err_equal(msg, LOCK_ERR_CANNOT_WRITE)
+	    || lock_err_equal(msg, LOCK_ERR_CANNOT_CLOSE)
+	    || lock_err_equal(msg, LOCK_ERR_MALFORMED)
+	    || lock_err_equal(msg, LOCK_ERR_CANNOT_REMOVE);
+}
 
 /**********************
  *
- * if successful, returns NULL  
+ * if successful, returns NULL
  * if file locked, returns username of person locking the file
  * if other error, returns "LOCK ERROR: explanation"
  *
  *********************/
-char *dolock(char *fname)
+const char *dolock(char *fname)
 {
-	int fd, n;
+	int fd;
 	static char lname[MAXLOCK], locker[MAXNAME + 1];
 	int mask;
 	struct stat sbuf;
+	ssize_t nread;
+	ssize_t nwritten;
+	size_t owner_len;
 
-	strcat(strcpy(lname, fname), ".lock~");
-
-	/* check that we are not being cheated, qname must point to     */
-	/* a regular file - even this code leaves a small window of     */
-	/* vulnerability but it is rather hard to exploit it            */
-
-#if defined(S_IFLNK)
-	if (lstat(lname, &sbuf) == 0)
-#else
-	if (stat(lname, &sbuf) == 0)
-#endif
-#if defined(S_ISREG)
-		if (!S_ISREG(sbuf.st_mode))
-#else
-		if (!(((sbuf.st_mode) & 070000) == 0))	/* SysV R2 */
-#endif
-			return "LOCK ERROR: not a regular file";
-
-	mask = umask(0);
-	fd = open(lname, O_RDWR | O_CREAT, 0666);
-	umask(mask);
-	if (fd < 0) {
-		if (errno == EACCES)
-			return NULL;
-#ifdef EROFS
-		if (errno == EROFS)
-			return NULL;
-#endif
-		return "LOCK ERROR: cannot access lock file";
+	if (snprintf(lname, sizeof(lname), "%s.lock~", fname)
+	    >= (int)sizeof(lname)) {
+		errno = ENAMETOOLONG;
+		return LOCK_ERR_PATH_TOO_LONG;
 	}
-	if ((n = read(fd, locker, MAXNAME)) < 1) {
-		lseek(fd, 0, SEEK_SET);
-/*		strcpy(locker, getlogin()); */
-		cuserid(locker);
-		strcat(locker + strlen(locker), "@");
-		gethostname(locker + strlen(locker), 64);
-		write(fd, locker, strlen(locker));
-		close(fd);
+
+retry_create:
+	mask = umask(0);
+	fd = open(lname,
+		  O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC | O_NOFOLLOW,
+		  0666);
+	umask(mask);
+
+	/* We created the lock file atomically and now own the lock. */
+	if (fd >= 0) {
+		if (fstat(fd, &sbuf) != 0) {
+			close(fd);
+			unlink(lname);
+			return LOCK_ERR_CANNOT_ACCESS;
+		}
+		if (!S_ISREG(sbuf.st_mode)) {
+			close(fd);
+			unlink(lname);
+			errno = ELOOP;
+			return LOCK_ERR_NOT_REGULAR;
+		}
+
+		/* Generate the owner tag (user@host) for the lock file */
+		const char *user = getlogin();
+		if (!user) {
+			/* No controlling terminal; try the passwd entry */
+			struct passwd *pw = getpwuid(geteuid());
+			if (pw)
+				user = pw->pw_name;
+		}
+
+		if (!user) {
+			/* Still no username; fall back to numeric UID */
+			snprintf(locker, sizeof(locker), "uid%d", (int)geteuid());
+		} else {
+			snprintf(locker, sizeof(locker), "%s", user);
+		}
+		{
+			size_t used = strlen(locker);
+
+			/* Append host safely without overflowing locker. */
+			if (used < sizeof(locker) - 1) {
+				locker[used++] = '@';
+				if (gethostname(locker + used,
+						sizeof(locker) - used) != 0)
+					locker[used] = '\0';
+				locker[sizeof(locker) - 1] = '\0';
+			}
+		}
+
+		/* Write the owner tag to the lock file */
+		owner_len = strlen(locker);
+		if (lseek(fd, 0, SEEK_SET) < 0) {
+			close(fd);
+			unlink(lname);
+			return LOCK_ERR_CANNOT_WRITE;
+		}
+		nwritten = write(fd, locker, owner_len);
+		if (nwritten < 0 || (size_t)nwritten != owner_len) {
+			close(fd);
+			unlink(lname);
+			return LOCK_ERR_CANNOT_WRITE;
+		}
+		if (close(fd) != 0) {
+			unlink(lname);
+			return LOCK_ERR_CANNOT_CLOSE;
+		}
 		return NULL;
 	}
-	locker[n > MAXNAME ? MAXNAME : n] = 0;
-	return locker;
-}
 
+	if (errno == EACCES || errno == EROFS)
+		return NULL;
+
+	/* A lock file exists: read and report its owner. */
+	if (errno == EEXIST) {
+		fd = open_existing_lock(lname, &sbuf);
+		if (fd < 0) {
+			if (errno == ENOENT)
+				goto retry_create;
+			if (errno == EACCES || errno == EROFS)
+				return NULL;
+			if (errno == ELOOP)
+				return LOCK_ERR_NOT_REGULAR;
+			return LOCK_ERR_CANNOT_ACCESS;
+		}
+
+		nread = read(fd, locker, MAXNAME);
+		if (close(fd) != 0 && nread >= 0)
+			return LOCK_ERR_CANNOT_ACCESS;
+		if (nread < 0)
+			return LOCK_ERR_CANNOT_ACCESS;
+		if (nread == 0) {
+			errno = EINVAL;
+			return LOCK_ERR_MALFORMED;
+		}
+
+		locker[nread > MAXNAME ? MAXNAME : nread] = '\0';
+		return locker;
+	}
+
+	if (errno == ELOOP)
+		return LOCK_ERR_NOT_REGULAR;
+	return LOCK_ERR_CANNOT_ACCESS;
+}
 
 /*********************
  *
@@ -102,20 +243,21 @@ char *dolock(char *fname)
  *
  *********************/
 
-char *undolock(char *fname)
+const char *undolock(char *fname)
 {
 	static char lname[MAXLOCK];
 
-	strcat(strcpy(lname, fname), ".lock~");
+	if (snprintf(lname, sizeof(lname), "%s.lock~", fname)
+	    >= (int)sizeof(lname)) {
+		errno = ENAMETOOLONG;
+		return LOCK_ERR_PATH_TOO_LONG;
+	}
 	if (unlink(lname) != 0) {
 		if (errno == EACCES || errno == ENOENT)
 			return NULL;
-#ifdef EROFS
 		if (errno == EROFS)
 			return NULL;
-#endif
-		return "LOCK ERROR: cannot remove lock file";
+		return LOCK_ERR_CANNOT_REMOVE;
 	}
 	return NULL;
 }
-#endif


### PR DESCRIPTION
Several problems in pklock.c/lock.c:

- cuserid() is deprecated and removed in POSIX.1-2008. The commented-out getlogin() call was already pointing at the fix. Replace cuserid() with getlogin(), falling back to getpwuid(geteuid()) when there is no controlling terminal, and to a numeric uid%d string as a last resort.

- The lock creation path uses O_RDWR|O_CREAT without O_EXCL, leaving a check-then-open race. Use O_CREAT|O_EXCL so the lock is acquired atomically. On EEXIST, open the existing file with O_RDONLY and fstat() to verify it is a regular file before reading the owner tag, using O_NOFOLLOW and O_CLOEXEC where available.

- strcat(strcpy(lname, fname), ".lock~") can overflow lname. Replace with snprintf() and return a distinct error if the path is too long.

- The "LOCK" string prefix sentinel in lock.c is fragile: any user whose name begins with "LOCK" would be misclassified as an error. Replace the strncmp check with is_lock_error(), which compares against the actual error string pointers returned by pklock.c.

- lock.c message assembly used unchecked strcpy/strcat into a fixed buffer. Replace with snprintf().

- Drop the SVR4/BSD preprocessor guards; the locking code is POSIX and builds fine without them.