### PR TITLE
Fix tautological overlap comparison in random.c

### DIFF
--- a/random.c
+++ b/random.c
@@ -140,7 +140,7 @@ int getccol(int bflg)
 			col |= tabmask;
 		else if (c < 0x20 || c == 0x7F)
 			++col;
-		else if (c >= 0xc0 && c <= 0xa0)
+		else if (c >= 0xa0 && c <= 0xc0)
 			col += 2;
 		++col;
 	}


### PR DESCRIPTION
The character range check \'c >= 0xc0 && c <= 0xa0\' always evaluated
to false, rendering the block dead code. This was caused by swapped
upper and lower bounds.

The commit corrects the condition to \'c >= 0xa0 && c <= 0xc0\' to
properly evaluate characters in that range and resolve the
-Wtautological-overlap-compare compiler warning.
